### PR TITLE
Sort generated entries

### DIFF
--- a/generator/setupgenerator.cpp
+++ b/generator/setupgenerator.cpp
@@ -64,6 +64,7 @@ void SetupGenerator::generate()
         QList<const AbstractMetaClass*> list = pack.value();
         if (list.isEmpty())
             continue;
+        std::sort(list.begin(), list.end());
 
         QString packName = pack.key();
         QStringList components = packName.split(".");


### PR DESCRIPTION
When building packages (e.g. for openSUSE Linux), varying ordering of
functions in the output would cause differing binaries.

See https://reproducible-builds.org/ for why this matters.

Change-Id: I29a2e54db766fba8a9cd3e5f1a1e552e603a7788
Reviewed-by: Oswald Buddenhagen <oswald.buddenhagen@qt.io>